### PR TITLE
Moved subscribing to events away from DbPlatform constructor

### DIFF
--- a/src/lib/Database/DbPlatform/DbPlatform.php
+++ b/src/lib/Database/DbPlatform/DbPlatform.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace EzSystems\DoctrineSchema\Database\DbPlatform;
 
+use Doctrine\Common\EventManager;
+
 interface DbPlatform
 {
     /**
@@ -21,4 +23,11 @@ interface DbPlatform
      * @return string
      */
     public function getDriverName(): string;
+
+    /**
+     * Add event subscribers predefined and required by an implementation.
+     *
+     * @param \Doctrine\Common\EventManager $eventManager
+     */
+    public function addEventSubscribers(EventManager $eventManager): void;
 }

--- a/src/lib/Database/DbPlatform/PostgreSqlDbPlatform.php
+++ b/src/lib/Database/DbPlatform/PostgreSqlDbPlatform.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\DoctrineSchema\Database\DbPlatform;
 
+use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Event\SchemaDropTableEventArgs;
 use Doctrine\DBAL\Events;
 use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
@@ -16,6 +17,13 @@ use InvalidArgumentException;
 
 class PostgreSqlDbPlatform extends PostgreSQL100Platform implements DbPlatform
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function addEventSubscribers(EventManager $eventManager): void
+    {
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/lib/Database/DbPlatform/SqliteDbPlatform.php
+++ b/src/lib/Database/DbPlatform/SqliteDbPlatform.php
@@ -16,10 +16,11 @@ use Doctrine\DBAL\Schema\Table;
 
 class SqliteDbPlatform extends SqlitePlatform implements DbPlatform
 {
-    public function __construct(EventManager $eventManager)
+    /**
+     * {@inheritdoc}
+     */
+    public function addEventSubscribers(EventManager $eventManager): void
     {
-        parent::__construct();
-
         $eventManager->addEventSubscriber(new SQLSessionInit('PRAGMA FOREIGN_KEYS = ON'));
     }
 

--- a/tests/lib/Database/Builder/SqliteTestDatabaseBuilder.php
+++ b/tests/lib/Database/Builder/SqliteTestDatabaseBuilder.php
@@ -23,12 +23,14 @@ class SqliteTestDatabaseBuilder implements TestDatabaseBuilder
      */
     public function buildDatabase(): Connection
     {
+        $dbPlatform = new SqliteDbPlatform();
         $eventManager = new EventManager();
+        $dbPlatform->addEventSubscribers($eventManager);
 
         return DriverManager::getConnection(
             [
                 'url' => 'sqlite:///:memory:',
-                'platform' => new SqliteDbPlatform($eventManager),
+                'platform' => $dbPlatform,
             ],
             new Configuration(),
             $eventManager

--- a/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
+++ b/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\DoctrineSchema\Database\DbPlatform;
 
-use Doctrine\Common\EventManager;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\ParameterType;
 use EzSystems\DoctrineSchema\Database\DbPlatform\SqliteDbPlatform;
@@ -29,7 +28,7 @@ class SqliteDbPlatformTest extends TestCase
 
     public function setUp(): void
     {
-        $this->sqliteDbPlatform = new SqliteDbPlatform(new EventManager());
+        $this->sqliteDbPlatform = new SqliteDbPlatform();
         $this->testDatabaseFactory = new TestDatabaseFactory();
     }
 

--- a/tests/lib/Exporter/SchemaExporterTest.php
+++ b/tests/lib/Exporter/SchemaExporterTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\DoctrineSchema\Exporter;
 
-use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -50,7 +49,7 @@ class SchemaExporterTest extends TestCase
     {
         $data = [];
 
-        $databasePlatforms = [new SqliteDbPlatform(new EventManager()), new MySqlPlatform()];
+        $databasePlatforms = [new SqliteDbPlatform(), new MySqlPlatform()];
 
         // iterate over output files to avoid loading it for each platform
         $directoryIterator = new \DirectoryIterator(__DIR__ . '/_fixtures/output');


### PR DESCRIPTION
| Q           |     A 
| ----------- | ----------- |
| **Type** | Bug
| **Target Version** | 0.1.x
| **Required by** | ezsystems/ezpublish-kernel#2612

## Summary
There's a bug related to the fact that I'm adding Event Subscriber inside `SqliteDbPlatform` constructor.
This is bad if used as a tagged Symfony service (list of DbPlatforms), because an event will be always added, even if in the end chosen DbPlatform is not Sqlite. 
This is what I get for not keeping constructors light as I should...

There's no other place (some kind of init) to add this, so I'm introducing on the interface a new method `addEventSubscribers` which needs to be called by factory building connection after proper DbPlatform is determined.

It mostly affects our tests right now, but will affect any implementation injecting tagged DbPlatforms.

## BC

Promise on API is for consumers only, so there are no BC breaks here. Anyway this is 0.x.