### PR TITLE
EZP-30812: Fixed deprecated use of Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch method

### DIFF
--- a/src/lib/Builder/SchemaBuilder.php
+++ b/src/lib/Builder/SchemaBuilder.php
@@ -68,7 +68,7 @@ class SchemaBuilder implements APISchemaBuilder
         $this->schema = new Schema([], [], $config);
         if ($this->eventDispatcher->hasListeners(SchemaBuilderEvents::BUILD_SCHEMA)) {
             $event = new SchemaBuilderEvent($this, $this->schema);
-            $this->eventDispatcher->dispatch(SchemaBuilderEvents::BUILD_SCHEMA, $event);
+            $this->eventDispatcher->dispatch($event, SchemaBuilderEvents::BUILD_SCHEMA);
         }
 
         return $this->schema;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30812

## Description 

Fixed the following deprecation message:

```
Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.
```

by swapping argument order in  `Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()` method calls.  
