### PR TITLE
EZP-30828: Replaced \Symfony\Component\EventDispatcher\Event usage in favour of Symfony\Contracts\EventDispatcher\Event

### DIFF
--- a/src/lib/API/Event/SchemaBuilderEvent.php
+++ b/src/lib/API/Event/SchemaBuilderEvent.php
@@ -10,7 +10,7 @@ namespace EzSystems\DoctrineSchema\API\Event;
 
 use Doctrine\DBAL\Schema\Schema;
 use EzSystems\DoctrineSchema\API\Builder\SchemaBuilder;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class SchemaBuilderEvent extends Event
 {

--- a/src/lib/API/Event/SchemaBuilderEvents.php
+++ b/src/lib/API/Event/SchemaBuilderEvents.php
@@ -8,9 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\DoctrineSchema\API\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-
-class SchemaBuilderEvents extends Event
+class SchemaBuilderEvents
 {
     const BUILD_SCHEMA = 'ez.schema.build_schema';
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30828

## Description 

Replaced `\Symfony\Component\EventDispatcher\Event` usage in favour of `Symfony\Contracts\EventDispatcher\Event`. 

Additionally, `\EzSystems\DoctrineSchema\API\Event\SchemaBuilderEvents` shouldn't extend  `Symfony\Component\EventDispatcher\Event` (there is not reason for it)