### PR TITLE
EZP-30846: Dropped deprecated Symfony\Component\Config\Definition\Builder\TreeBuilder::root method calls

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -21,9 +21,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ez_doctrine_schema');
+        $treeBuilder = new TreeBuilder('ez_doctrine_schema');
 
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode
             ->children()
                 ->arrayNode('tables')


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30846

## Description 

Since Symfony 4.3 configuration root name should be passed via constructor instead of using "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method.

More information:
* https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes
* https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config