### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: focal
+dist: trusty
 
 services:
     - mysql
@@ -21,16 +21,16 @@ matrix:
           php: '7.3'
           env: CMD='php ./vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=estimating'
 
-# test only master, stable branches and pull requests
+#A test only master, stable branches and pull requests
 branches:
     only:
         - master
         - /^\d.\d+$/
 
 before_install:
-    # Disable memory_limit for composer
+    #A Disable memory_limit for composer
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    # Create MySQL database for tests
+    #A Create MySQL database for tests
     - mysql -e 'CREATE DATABASE testdb;'
 
 install:
@@ -40,14 +40,14 @@ script:
     - composer validate
     - "$CMD"
 
-# reduce depth (history) of git checkout
+#A reduce depth (history) of git checkout
 git:
     depth: 10
 
 notifications:
-    # disable mail notifications
+    #A disable mail notifications
     email: false
-    # enable Slack notifications
+    #A enable Slack notifications
     slack:
         rooms:
             - secure: "ENo6GDuEaX9T2P6DWR7A3R3xveLnQV5Psue4dH6ZIQ4Y3jrLBjJsZ4NjAm24GSt7ycez/4OXVhPsX12BofiB/yePoReNfA9ULPJw/ZX2xFg/LpLxHua7UQcIDw7D5qsWJtSXEyuf5Rc61OGnMcKw8yKyhebPYbcLWRQ0awdQRUXuca3gNQNiSdfgtNrQCh3vGx1LYnqG7+ZryQ0MG2SEB6sjnSVeAzGHCBKHvr6gLKuUsyEeBziQopuplcQiTJKzngDiHJQCkOhJKgPkHiKG+zkQG+qF8L4oOUCU1baMfWofkg/iFYxOEEFupUWKBT4X9hcXPKW5ieml/jUXmhrEBpNy8yhkixPmOjSBYf6TTsMHL9UvwlY95Ll/HM3H/09b6ckPoop00gSrBdyc5a4x12cwTcFJrsZugviT8Bps1Ej4fCxfKVZWvbpasg263w4T0G8w72WyjDkeF+Vdl0vw2yavXGmciWP+MS7MG/QEWyJDVjYaRYxrvFzuld0Z7boZzKQOa242immOzQWHWhhiW1KxgALyvBE+0yPDP7Usw1U/6NjHkJLCpkigccBZe7TMUp9LmuhFZSBcLIioNt+d01F1V8O6z24GXmW2bMFJzjCwD7tyf2yNBDJ2APCjBYMTJLlAp8cIqmwNgN7umoFW880gLqmKiaMZFyIEf+Q8AqE="

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,16 @@ matrix:
           php: '7.3'
           env: CMD='php ./vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=estimating'
 
-#A test only master, stable branches and pull requests
+# test only master, stable branches and pull requests
 branches:
     only:
         - master
         - /^\d.\d+$/
 
 before_install:
-    #A Disable memory_limit for composer
+    # Disable memory_limit for composer
     - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    #A Create MySQL database for tests
+    # Create MySQL database for tests
     - mysql -e 'CREATE DATABASE testdb;'
 
 install:
@@ -40,14 +40,14 @@ script:
     - composer validate
     - "$CMD"
 
-#A reduce depth (history) of git checkout
+# reduce depth (history) of git checkout
 git:
     depth: 10
 
 notifications:
-    #A disable mail notifications
+    # disable mail notifications
     email: false
-    #A enable Slack notifications
+    # enable Slack notifications
     slack:
         rooms:
             - secure: "ENo6GDuEaX9T2P6DWR7A3R3xveLnQV5Psue4dH6ZIQ4Y3jrLBjJsZ4NjAm24GSt7ycez/4OXVhPsX12BofiB/yePoReNfA9ULPJw/ZX2xFg/LpLxHua7UQcIDw7D5qsWJtSXEyuf5Rc61OGnMcKw8yKyhebPYbcLWRQ0awdQRUXuca3gNQNiSdfgtNrQCh3vGx1LYnqG7+ZryQ0MG2SEB6sjnSVeAzGHCBKHvr6gLKuUsyEeBziQopuplcQiTJKzngDiHJQCkOhJKgPkHiKG+zkQG+qF8L4oOUCU1baMfWofkg/iFYxOEEFupUWKBT4X9hcXPKW5ieml/jUXmhrEBpNy8yhkixPmOjSBYf6TTsMHL9UvwlY95Ll/HM3H/09b6ckPoop00gSrBdyc5a4x12cwTcFJrsZugviT8Bps1Ej4fCxfKVZWvbpasg263w4T0G8w72WyjDkeF+Vdl0vw2yavXGmciWP+MS7MG/QEWyJDVjYaRYxrvFzuld0Z7boZzKQOa242immOzQWHWhhiW1KxgALyvBE+0yPDP7Usw1U/6NjHkJLCpkigccBZe7TMUp9LmuhFZSBcLIioNt+d01F1V8O6z24GXmW2bMFJzjCwD7tyf2yNBDJ2APCjBYMTJLlAp8cIqmwNgN7umoFW880gLqmKiaMZFyIEf+Q8AqE="

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: xenial
+dist: focal
 
 services:
     - mysql


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.