### PR TITLE
IBX-1247: Promoted `scale` & `precision` as top-level field options

### DIFF
--- a/src/lib/Importer/SchemaImporter.php
+++ b/src/lib/Importer/SchemaImporter.php
@@ -134,6 +134,14 @@ class SchemaImporter implements APISchemaImporter
                 $columnConfiguration['options']['length'] = $columnConfiguration['length'];
             }
 
+            if (isset($columnConfiguration['scale'])) {
+                $columnConfiguration['options']['scale'] = $columnConfiguration['scale'];
+            }
+
+            if (isset($columnConfiguration['precision'])) {
+                $columnConfiguration['options']['precision'] = $columnConfiguration['precision'];
+            }
+
             $column = $table->addColumn(
                 $columnName,
                 $columnConfiguration['type'],

--- a/tests/lib/Importer/SchemaImporterTest.php
+++ b/tests/lib/Importer/SchemaImporterTest.php
@@ -170,6 +170,22 @@ class SchemaImporterTest extends TestCase
                     ]
                 ),
             ],
+            7 => [
+                '07-numeric-options.yaml',
+                new Schema(
+                    [
+                        new Table(
+                            'my_table',
+                            [
+                                (new Column(
+                                    'data',
+                                    Type::getType('decimal'))
+                                )->setPrecision(19)->setScale(4),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
         ];
 
         return $data;

--- a/tests/lib/Importer/_fixtures/07-numeric-options.yaml
+++ b/tests/lib/Importer/_fixtures/07-numeric-options.yaml
@@ -1,0 +1,4 @@
+tables:
+    my_table:
+        fields:
+            data: { type: decimal, precision: 19, scale: 4 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1247](https://issues.ibexa.co/browse/IBX-1247)
| **Type**                                   | improvement
| **Target Ibexa version** | `v2.5`
| **BC breaks**                          | no

Allows:
```yaml
    ibexa_table:
        fields:
            amount:
                type: decimal
                nullable: false
                precision: 5
                scale: 2
                options:
                    default: 0

```

Instead of:
```yaml
    ibexa_table:
        fields:
            amount:
                type: decimal
                nullable: false
                options:
                    precision: 5
                    scale: 2
                    default: 0
```

Which makes it behave in the same fashion as Doctrine ORM annotations (which also have `precision` & `numeric` on this level).
Without this change, detecting invalid `NUMERIC` column configuration is a lot more difficult - I've stumbled upon this at least twice, which caused me to lose time to find out that values in database are truncated, effectively making them integers :disappointed: 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
